### PR TITLE
add href and alt in logo image at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 <div align="center">
-<img src="docs/assets/logo-github.png">
 
+<a href="https://zora.undistro.io/" target="_blank">
+    <img src="docs/assets/logo-github.png" alt="Zora Logo">
+</a>
+
+[![build](https://github.com/getupio-undistro/zora/actions/workflows/build.yaml/badge.svg)](https://github.com/getupio-undistro/zora/actions/workflows/build.yaml)
 [![license](https://img.shields.io/github/license/getupio-undistro/zora)](https://github.com/getupio-undistro/zora/blob/main/LICENSE)
 [![version](https://img.shields.io/github/v/tag/getupio-undistro/zora?sort=semver)](https://github.com/getupio-undistro/zora/tags)
-[![build](https://github.com/getupio-undistro/zora/actions/workflows/build.yaml/badge.svg)](https://github.com/getupio-undistro/zora/actions/workflows/build.yaml)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fgetupio-undistro%2Fzora.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fgetupio-undistro%2Fzora?ref=badge_shield)
 
 [📖 Documentation](https://zora.undistro.io)


### PR DESCRIPTION
## Description
Update README.md to add `href` and `alt` attributes in logo image

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/getupio-undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [ ] My changes are covered by tests
